### PR TITLE
修改上海市闵行区中医院的资料：增加医院改公办前曾用名

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Open Power小组会以这三个入选条件作为指导原则，明确更详细�
 [](hospital list begin //PLEASE DO NOT DELETE THIS LINE)
 ## 上海
 
-- 上海市闵行区中医医院
+- 上海市闵行区中医医院（上海莱茵医院）
  - 电话 021-51876888
  - 网址 http://www.tcmmh.com
  - 地址 上海市闵行区合川路3071号


### PR DESCRIPTION
该医院目前身份是公立二级甲等医院，然而该医院仍然和莆田系有联系
标明医院原名以供参考